### PR TITLE
Add multi-region iSolarCloud support (EU, AU, CN, International)

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,9 +19,38 @@ along with com.sungrowpower.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
-// const Homey = require('homey');
+const Homey = require('homey');
 const { OAuth2App } = require('homey-oauth2app');
 const SungrowOAuth2Client = require('./lib/SungrowOAuth2Client');
+
+const REDIRECT_URL = 'https://callback.athom.com/oauth2/callback/';
+
+// iSolarCloud runs parallel regional stacks, each with its own API gateway + web authorization
+// host and a numeric cloudId that the authorization page uses to route to the correct cloud.
+// Gateways come from the iSolarCloud OpenAPI server list; auth hosts + cloudIds are confirmed
+// against the working Home Assistant iSolarCloud integration (China=1, International=2, EU=3,
+// Australia=7).
+//
+// applicationId identifies the *registered developer app* on that region's portal and is unique
+// per registration. EU uses 1162 (Robin's app, from the v1.0.2 release). For other regions it
+// must be supplied via env.json (e.g. APPLICATION_ID_AU), together with that region's appkey
+// (CLIENT_ID_AU / CLIENT_SECRET_AU) if it differs from the default.
+//
+// The auto-registered `default` config mirrors EU so devices paired with v1.0.2 keep working.
+const REGIONS = [
+  {
+    configId: 'eu', name: 'Europe', apiUrl: 'https://gateway.isolarcloud.eu', authHost: 'web3.isolarcloud.eu', cloudId: '3', applicationId: '1162',
+  },
+  {
+    configId: 'au', name: 'Australia', apiUrl: 'https://augateway.isolarcloud.com', authHost: 'auweb3.isolarcloud.com', cloudId: '7',
+  },
+  {
+    configId: 'cn', name: 'China', apiUrl: 'https://gateway.isolarcloud.com', authHost: 'web3.isolarcloud.com.cn', cloudId: '1',
+  },
+  {
+    configId: 'intl', name: 'International', apiUrl: 'https://gateway.isolarcloud.com.hk', authHost: 'web3.isolarcloud.com.hk', cloudId: '2',
+  },
+];
 
 module.exports = class SungrowApp extends OAuth2App {
 
@@ -31,8 +60,48 @@ module.exports = class SungrowApp extends OAuth2App {
   // static OAUTH2_DRIVERS = ['inverter', 'battery']; // Default: all drivers
 
   async onOAuth2Init() {
+    this.registerRegionConfigs();
     this.everyXminutes(1); // start time trigger emitter
     this.log('Sungrow app has been initialized with OAuth2');
+  }
+
+  // Register one OAuth2 config per iSolarCloud region. The driver's pick_region pair step
+  // selects which configId a new pairing uses, swapping gateway + authorization host together.
+  //
+  // IMPORTANT (homey-oauth2app@3.7.2 quirk): setOAuth2Config()'s duplicate-check passes a bare
+  // string to hasConfig(), which JS resolves to the 'default' key. The practical effect is that
+  // once a 'default' config exists, every further setOAuth2Config() throws "Duplicate Config ID".
+  // So: the client leaves API_URL/TOKEN_URL null (suppressing the library's automatic 'default'
+  // registration at init), we register every regional config FIRST, and register 'default' LAST.
+  // 'default' mirrors EU so devices paired on v1.0.2 (which stored OAuth2ConfigId 'default') keep
+  // working.
+  registerRegionConfigs() {
+    const buildConfig = (region) => {
+      const suffix = region.configId.toUpperCase();
+      const cloudId = Homey.env[`CLOUD_ID_${suffix}`] || region.cloudId;
+      const applicationId = Homey.env[`APPLICATION_ID_${suffix}`] || region.applicationId;
+      return {
+        clientId: Homey.env[`CLIENT_ID_${suffix}`] || Homey.env.CLIENT_ID,
+        clientSecret: Homey.env[`CLIENT_SECRET_${suffix}`] || Homey.env.CLIENT_SECRET,
+        apiUrl: region.apiUrl,
+        tokenUrl: `${region.apiUrl}/openapi/apiManage/token`,
+        authorizationUrl: `https://${region.authHost}/#/authorized-app?cloudId=${cloudId}&applicationId=${applicationId}&redirectUrl=${REDIRECT_URL}`,
+        redirectUrl: REDIRECT_URL,
+      };
+    };
+
+    const register = (configId, region) => {
+      if (this.hasConfig({ configId })) return; // idempotent if init runs twice
+      this.setOAuth2Config({ configId, ...buildConfig(region) });
+      this.log(`Registered OAuth2 config '${configId}' (${region.apiUrl})`);
+    };
+
+    // Regional configs first...
+    for (const region of REGIONS) register(region.configId, region);
+
+    // ...then 'default' (EU) LAST, for backward compatibility with v1.0.2 devices.
+    const eu = REGIONS.find((r) => r.configId === 'eu');
+    register('default', eu);
   }
 
   async onOAuth2Uninit() {

--- a/app.json
+++ b/app.json
@@ -267,6 +267,12 @@
       },
       "pair": [
         {
+          "id": "pick_region",
+          "navigation": {
+            "next": "login_oauth2"
+          }
+        },
+        {
           "id": "login_oauth2",
           "template": "login_oauth2",
           "options": {
@@ -380,6 +386,12 @@
         "xlarge": "/drivers/charger/assets/images/xlarge.png"
       },
       "pair": [
+        {
+          "id": "pick_region",
+          "navigation": {
+            "next": "login_oauth2"
+          }
+        },
         {
           "id": "login_oauth2",
           "template": "login_oauth2",
@@ -505,6 +517,12 @@
         "xlarge": "/drivers/inverter/assets/images/xlarge.png"
       },
       "pair": [
+        {
+          "id": "pick_region",
+          "navigation": {
+            "next": "login_oauth2"
+          }
+        },
         {
           "id": "login_oauth2",
           "template": "login_oauth2",
@@ -660,6 +678,12 @@
         "xlarge": "/drivers/meter/assets/images/xlarge.png"
       },
       "pair": [
+        {
+          "id": "pick_region",
+          "navigation": {
+            "next": "login_oauth2"
+          }
+        },
         {
           "id": "login_oauth2",
           "template": "login_oauth2",

--- a/common_driver.js
+++ b/common_driver.js
@@ -129,8 +129,6 @@ module.exports = class MyBrandDriver extends OAuth2Driver {
   async onPairListDevices({ oAuth2Client }) {
     const devices = [];
     const result = await oAuth2Client.getPlantList().catch(this.error);
-    this.log('getPlantList raw result:', JSON.stringify(result)); // TEMP DEBUG
-    // console.dir(result, { depth: null });
     if (!result || !result.result_data || !result.result_data.pageList) return devices;
     const validTypes = Object.keys(sungrowPointMap[`${this.id}Points`]);
     const sites = result.result_data.pageList;

--- a/common_driver.js
+++ b/common_driver.js
@@ -29,9 +29,107 @@ module.exports = class MyBrandDriver extends OAuth2Driver {
     this.log('Inverter driver has been initialized with OAuth2');
   }
 
+  /**
+   * Custom pair flow with a region picker.
+   *
+   * The stock OAuth2Driver.onPair() captures the configId and builds the pair client up-front,
+   * so it can't switch regions mid-flow. We reimplement the (single-session) OAuth2 code flow
+   * here and add a `set_region` handler that rebuilds the pair client against the chosen config
+   * before the login_oauth2 view requests an authorization URL.
+   * @param {PairSession} socket
+   */
+  onPair(socket) {
+    let configId = this.getOAuth2ConfigId(); // 'default' (EU) until the user picks a region
+    let sessionId = null;
+    let client;
+
+    const newPairClient = () => {
+      if (client) {
+        try {
+          client.destroy();
+        } catch (err) {
+          this.error(err);
+        }
+      }
+      client = this.homey.app.createOAuth2Client({
+        sessionId: `pair-${Date.now()}-${Math.round(Math.random() * 1e9)}`,
+        configId,
+      });
+    };
+    newPairClient();
+
+    const onSetRegion = async (regionId) => {
+      if (!this.homey.app.hasConfig({ configId: regionId })) {
+        throw new Error(`Unknown region: ${regionId}`);
+      }
+      configId = regionId;
+      this.log(`Pairing region selected: ${configId}`);
+      newPairClient();
+      return true;
+    };
+
+    const onShowViewLoginOAuth2 = async () => {
+      try {
+        const authorizationUrl = client.getAuthorizationUrl();
+        const oAuth2Callback = await this.homey.cloud.createOAuth2Callback(authorizationUrl);
+        oAuth2Callback
+          .on('url', (url) => socket.emit('url', url).catch(this.error))
+          .on('code', (code) => {
+            client.getTokenByCode({ code })
+              .then(async () => {
+                const session = await client.onGetOAuth2SessionInformation();
+                const token = client.getToken();
+                const { title } = session;
+                sessionId = session.id;
+
+                // Swap the temporary pair client for the final, persistable one
+                client.destroy();
+                client = this.homey.app.createOAuth2Client({ sessionId, configId });
+                client.setTitle({ title });
+                client.setToken({ token });
+
+                socket.emit('authorized').catch(this.error);
+              })
+              .catch((err) => socket.emit('error', err.message || err.toString()).catch(this.error));
+          });
+      } catch (err) {
+        socket.emit('error', err.message || err.toString()).catch(this.error);
+      }
+    };
+
+    const onShowView = async (viewId) => {
+      if (viewId === 'login_oauth2') await onShowViewLoginOAuth2();
+    };
+
+    const onListDevices = async () => {
+      const devices = await this.onPairListDevices({ oAuth2Client: client });
+      return devices.map((device) => ({
+        ...device,
+        store: {
+          ...device.store,
+          OAuth2SessionId: sessionId,
+          OAuth2ConfigId: configId,
+        },
+      }));
+    };
+
+    const onAddDevice = async () => {
+      this.log(`At least one device has been added, saving the '${configId}' client...`);
+      client.save();
+    };
+
+    socket
+      .setHandler('set_region', onSetRegion)
+      .setHandler('showView', onShowView)
+      .setHandler('list_devices', onListDevices)
+      .setHandler('add_device', onAddDevice)
+      .setHandler('disconnect', async () => this.log('Pair session disconnected'));
+  }
+
   async onPairListDevices({ oAuth2Client }) {
     const devices = [];
     const result = await oAuth2Client.getPlantList().catch(this.error);
+    this.log('getPlantList raw result:', JSON.stringify(result)); // TEMP DEBUG
     // console.dir(result, { depth: null });
     if (!result || !result.result_data || !result.result_data.pageList) return devices;
     const validTypes = Object.keys(sungrowPointMap[`${this.id}Points`]);

--- a/drivers/battery/driver.compose.json
+++ b/drivers/battery/driver.compose.json
@@ -35,6 +35,12 @@
   },
   "pair": [
     {
+      "id": "pick_region",
+      "navigation": {
+        "next": "login_oauth2"
+      }
+    },
+    {
       "id": "login_oauth2",
       "template": "login_oauth2",
       "options": {

--- a/drivers/battery/pair/pick_region.html
+++ b/drivers/battery/pair/pick_region.html
@@ -1,0 +1,46 @@
+<script type="text/javascript">
+  // iSolarCloud regions. The id must match a configId registered in app.js (registerRegionConfigs).
+  var REGIONS = [
+    { id: 'eu', name: 'Europe', host: 'gateway.isolarcloud.eu' },
+    { id: 'au', name: 'Australia', host: 'augateway.isolarcloud.com' },
+    { id: 'cn', name: 'China', host: 'gateway.isolarcloud.com' },
+    { id: 'intl', name: 'International', host: 'gateway.isolarcloud.com.hk' }
+  ];
+
+  function selectRegion(regionId, button) {
+    var buttons = document.querySelectorAll('button[data-region]');
+    buttons.forEach(function (b) { b.disabled = true; });
+    button.classList.add('is-loading');
+
+    Homey.emit('set_region', regionId, function (err) {
+      if (err) {
+        button.classList.remove('is-loading');
+        buttons.forEach(function (b) { b.disabled = false; });
+        return Homey.alert(err.message || err.toString(), 'error');
+      }
+      Homey.showView('login_oauth2');
+    });
+  }
+
+  function renderRegions() {
+    var container = document.getElementById('regions');
+    REGIONS.forEach(function (region) {
+      var button = document.createElement('button');
+      button.className = 'homey-button-primary-full';
+      button.style.marginBottom = '8px';
+      button.setAttribute('data-region', region.id);
+      button.innerHTML = '<b>' + region.name + '</b><br><small>' + region.host + '</small>';
+      button.onclick = function () { selectRegion(region.id, button); };
+      container.appendChild(button);
+    });
+  }
+
+  Homey.setTitle('Select your region');
+  renderRegions();
+  Homey.ready();
+</script>
+
+<div class="homey-form-group">
+  <p class="homey-text">Choose the iSolarCloud region your account belongs to. This determines which gateway and login page is used.</p>
+</div>
+<div id="regions"></div>

--- a/drivers/charger/driver.compose.json
+++ b/drivers/charger/driver.compose.json
@@ -24,6 +24,12 @@
   },
   "pair": [
     {
+      "id": "pick_region",
+      "navigation": {
+        "next": "login_oauth2"
+      }
+    },
+    {
       "id": "login_oauth2",
       "template": "login_oauth2",
       "options": {

--- a/drivers/charger/pair/pick_region.html
+++ b/drivers/charger/pair/pick_region.html
@@ -1,0 +1,46 @@
+<script type="text/javascript">
+  // iSolarCloud regions. The id must match a configId registered in app.js (registerRegionConfigs).
+  var REGIONS = [
+    { id: 'eu', name: 'Europe', host: 'gateway.isolarcloud.eu' },
+    { id: 'au', name: 'Australia', host: 'augateway.isolarcloud.com' },
+    { id: 'cn', name: 'China', host: 'gateway.isolarcloud.com' },
+    { id: 'intl', name: 'International', host: 'gateway.isolarcloud.com.hk' }
+  ];
+
+  function selectRegion(regionId, button) {
+    var buttons = document.querySelectorAll('button[data-region]');
+    buttons.forEach(function (b) { b.disabled = true; });
+    button.classList.add('is-loading');
+
+    Homey.emit('set_region', regionId, function (err) {
+      if (err) {
+        button.classList.remove('is-loading');
+        buttons.forEach(function (b) { b.disabled = false; });
+        return Homey.alert(err.message || err.toString(), 'error');
+      }
+      Homey.showView('login_oauth2');
+    });
+  }
+
+  function renderRegions() {
+    var container = document.getElementById('regions');
+    REGIONS.forEach(function (region) {
+      var button = document.createElement('button');
+      button.className = 'homey-button-primary-full';
+      button.style.marginBottom = '8px';
+      button.setAttribute('data-region', region.id);
+      button.innerHTML = '<b>' + region.name + '</b><br><small>' + region.host + '</small>';
+      button.onclick = function () { selectRegion(region.id, button); };
+      container.appendChild(button);
+    });
+  }
+
+  Homey.setTitle('Select your region');
+  renderRegions();
+  Homey.ready();
+</script>
+
+<div class="homey-form-group">
+  <p class="homey-text">Choose the iSolarCloud region your account belongs to. This determines which gateway and login page is used.</p>
+</div>
+<div id="regions"></div>

--- a/drivers/inverter/driver.compose.json
+++ b/drivers/inverter/driver.compose.json
@@ -35,6 +35,12 @@
   },
   "pair": [
     {
+      "id": "pick_region",
+      "navigation": {
+        "next": "login_oauth2"
+      }
+    },
+    {
       "id": "login_oauth2",
       "template": "login_oauth2",
       "options": {

--- a/drivers/inverter/pair/pick_region.html
+++ b/drivers/inverter/pair/pick_region.html
@@ -1,0 +1,46 @@
+<script type="text/javascript">
+  // iSolarCloud regions. The id must match a configId registered in app.js (registerRegionConfigs).
+  var REGIONS = [
+    { id: 'eu', name: 'Europe', host: 'gateway.isolarcloud.eu' },
+    { id: 'au', name: 'Australia', host: 'augateway.isolarcloud.com' },
+    { id: 'cn', name: 'China', host: 'gateway.isolarcloud.com' },
+    { id: 'intl', name: 'International', host: 'gateway.isolarcloud.com.hk' }
+  ];
+
+  function selectRegion(regionId, button) {
+    var buttons = document.querySelectorAll('button[data-region]');
+    buttons.forEach(function (b) { b.disabled = true; });
+    button.classList.add('is-loading');
+
+    Homey.emit('set_region', regionId, function (err) {
+      if (err) {
+        button.classList.remove('is-loading');
+        buttons.forEach(function (b) { b.disabled = false; });
+        return Homey.alert(err.message || err.toString(), 'error');
+      }
+      Homey.showView('login_oauth2');
+    });
+  }
+
+  function renderRegions() {
+    var container = document.getElementById('regions');
+    REGIONS.forEach(function (region) {
+      var button = document.createElement('button');
+      button.className = 'homey-button-primary-full';
+      button.style.marginBottom = '8px';
+      button.setAttribute('data-region', region.id);
+      button.innerHTML = '<b>' + region.name + '</b><br><small>' + region.host + '</small>';
+      button.onclick = function () { selectRegion(region.id, button); };
+      container.appendChild(button);
+    });
+  }
+
+  Homey.setTitle('Select your region');
+  renderRegions();
+  Homey.ready();
+</script>
+
+<div class="homey-form-group">
+  <p class="homey-text">Choose the iSolarCloud region your account belongs to. This determines which gateway and login page is used.</p>
+</div>
+<div id="regions"></div>

--- a/drivers/meter/driver.compose.json
+++ b/drivers/meter/driver.compose.json
@@ -65,6 +65,12 @@
   },
   "pair": [
     {
+      "id": "pick_region",
+      "navigation": {
+        "next": "login_oauth2"
+      }
+    },
+    {
       "id": "login_oauth2",
       "template": "login_oauth2",
       "options": {

--- a/drivers/meter/pair/pick_region.html
+++ b/drivers/meter/pair/pick_region.html
@@ -1,0 +1,46 @@
+<script type="text/javascript">
+  // iSolarCloud regions. The id must match a configId registered in app.js (registerRegionConfigs).
+  var REGIONS = [
+    { id: 'eu', name: 'Europe', host: 'gateway.isolarcloud.eu' },
+    { id: 'au', name: 'Australia', host: 'augateway.isolarcloud.com' },
+    { id: 'cn', name: 'China', host: 'gateway.isolarcloud.com' },
+    { id: 'intl', name: 'International', host: 'gateway.isolarcloud.com.hk' }
+  ];
+
+  function selectRegion(regionId, button) {
+    var buttons = document.querySelectorAll('button[data-region]');
+    buttons.forEach(function (b) { b.disabled = true; });
+    button.classList.add('is-loading');
+
+    Homey.emit('set_region', regionId, function (err) {
+      if (err) {
+        button.classList.remove('is-loading');
+        buttons.forEach(function (b) { b.disabled = false; });
+        return Homey.alert(err.message || err.toString(), 'error');
+      }
+      Homey.showView('login_oauth2');
+    });
+  }
+
+  function renderRegions() {
+    var container = document.getElementById('regions');
+    REGIONS.forEach(function (region) {
+      var button = document.createElement('button');
+      button.className = 'homey-button-primary-full';
+      button.style.marginBottom = '8px';
+      button.setAttribute('data-region', region.id);
+      button.innerHTML = '<b>' + region.name + '</b><br><small>' + region.host + '</small>';
+      button.onclick = function () { selectRegion(region.id, button); };
+      container.appendChild(button);
+    });
+  }
+
+  Homey.setTitle('Select your region');
+  renderRegions();
+  Homey.ready();
+</script>
+
+<div class="homey-form-group">
+  <p class="homey-text">Choose the iSolarCloud region your account belongs to. This determines which gateway and login page is used.</p>
+</div>
+<div id="regions"></div>

--- a/lib/SungrowOAuth2Client.js
+++ b/lib/SungrowOAuth2Client.js
@@ -28,10 +28,16 @@ module.exports = class MyBrandOAuth2Client extends OAuth2Client {
   static CLIENT_SECRET = Homey.env.CLIENT_SECRET;
   // static APPLICATION_ID = Homey.env.APPLICATION_ID; // '1162'
   // static CLOUD_ID = Homey.env.CLOUD_ID; // '3'
-  static API_URL = 'https://gateway.isolarcloud.eu';
-  static TOKEN_URL = 'https://gateway.isolarcloud.eu/openapi/apiManage/token';
-  static REFRESH_URL = 'https://gateway.isolarcloud.eu/openapi/apiManage/refreshToken';
-  static AUTHORIZATION_URL = 'https://web3.isolarcloud.eu/#/authorized-app?cloudId=3&applicationId=1162&redirectUrl=https://callback.athom.com/oauth2/callback/';
+  // API_URL / TOKEN_URL / AUTHORIZATION_URL are intentionally left null so that
+  // OAuth2App does NOT auto-register a 'default' config at init. All configs
+  // (per-region + a 'default' for backward compatibility) are registered
+  // explicitly in app.js -> registerRegionConfigs(). See the note there: the
+  // library's duplicate-check is keyed on 'default', so 'default' must be the
+  // LAST config registered. Per-region token/refresh URLs are derived from the
+  // active config's apiUrl via the getters below.
+  static API_URL = null;
+  static TOKEN_URL = null;
+  static AUTHORIZATION_URL = null;
   // static SCOPES = [] // Optional:
   // static TOKEN = OAuth2Token; // SungrowAuth2Token; // Default: OAuth2Token
   static REDIRECT_URL = 'https://callback.athom.com/oauth2/callback/';
@@ -42,6 +48,16 @@ module.exports = class MyBrandOAuth2Client extends OAuth2Client {
     throw new OAuth2Error(body.error);
   }
 
+  // Per-region token endpoint, derived from the active config's apiUrl
+  get tokenUrl() {
+    return `${this._apiUrl}/openapi/apiManage/token`;
+  }
+
+  // Per-region refresh endpoint, derived from the active config's apiUrl
+  get refreshUrl() {
+    return `${this._apiUrl}/openapi/apiManage/refreshToken`;
+  }
+
   async onGetTokenByCode({ code }) {
     this.log('got code,', code);
     // Make call to token endpoint with right body / headers
@@ -49,16 +65,16 @@ module.exports = class MyBrandOAuth2Client extends OAuth2Client {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-access-key': this.constructor.CLIENT_SECRET,
+        'x-access-key': this._clientSecret,
       },
       body: JSON.stringify({
-        appkey: this.constructor.CLIENT_ID,
+        appkey: this._clientId,
         grant_type: 'authorization_code',
         code,
-        redirect_uri: this.constructor.REDIRECT_URL,
+        redirect_uri: this._redirectUrl,
       }),
     };
-    const response = await fetch(this.constructor.TOKEN_URL, options);
+    const response = await fetch(this.tokenUrl, options);
     if (!response.ok) {
       this.log(response);
       return this.onHandleGetTokenByCodeError({ response });
@@ -75,15 +91,15 @@ module.exports = class MyBrandOAuth2Client extends OAuth2Client {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-access-key': this.constructor.CLIENT_SECRET,
+        'x-access-key': this._clientSecret,
       },
       body: JSON.stringify({
-        appkey: this.constructor.CLIENT_ID,
+        appkey: this._clientId,
         grant_type: 'refresh_token',
         refresh_token: this._token.refresh_token,
       }),
     };
-    const response = await fetch(this.constructor.REFRESH_URL, options);
+    const response = await fetch(this.refreshUrl, options);
     if (!response.ok) {
       this.error(response);
       return this.onHandleRefreshTokenError({ response });
@@ -115,16 +131,16 @@ module.exports = class MyBrandOAuth2Client extends OAuth2Client {
       path: '/openapi/platform/queryPowerStationList',
       headers: {
         'Content-Type': 'application/json',
-        'x-access-key': this.constructor.CLIENT_SECRET,
+        'x-access-key': this._clientSecret,
       },
       body: JSON.stringify({
-        appkey: this.constructor.CLIENT_ID,
+        appkey: this._clientId,
         lang: '_en_US',
         // ps_type: '1,3,4,5,6,7,8',
         ps_name: '',
         valid_flag: '1,2,3',
         page: 1,
-        size: 9999,
+        size: 1000,
       }),
     });
   }
@@ -134,10 +150,10 @@ module.exports = class MyBrandOAuth2Client extends OAuth2Client {
       path: '/openapi/platform/getPowerStationDetail',
       headers: {
         'Content-Type': 'application/json',
-        'x-access-key': this.constructor.CLIENT_SECRET,
+        'x-access-key': this._clientSecret,
       },
       body: JSON.stringify({
-        appkey: this.constructor.CLIENT_ID,
+        appkey: this._clientId,
         lang: '_en_US',
         ps_ids: `${psId}`, // Comma-separated list of power station IDs
       }),
@@ -149,14 +165,14 @@ module.exports = class MyBrandOAuth2Client extends OAuth2Client {
       path: '/openapi/platform/getDeviceListByPsId',
       headers: {
         'Content-Type': 'application/json',
-        'x-access-key': this.constructor.CLIENT_SECRET,
+        'x-access-key': this._clientSecret,
       },
       body: JSON.stringify({
-        appkey: this.constructor.CLIENT_ID,
+        appkey: this._clientId,
         lang: '_en_US',
         ps_id: `${psId}`,
         page: 1,
-        size: 9999,
+        size: 1000,
       }),
     });
   }
@@ -166,10 +182,10 @@ module.exports = class MyBrandOAuth2Client extends OAuth2Client {
       path: '/openapi/platform/getPowerStationRealTimeData',
       headers: {
         'Content-Type': 'application/json',
-        'x-access-key': this.constructor.CLIENT_SECRET,
+        'x-access-key': this._clientSecret,
       },
       body: JSON.stringify({
-        appkey: this.constructor.CLIENT_ID,
+        appkey: this._clientId,
         lang: '_en_US',
         ps_id_list: psIdList,
         point_id_list: pointIdList,
@@ -185,10 +201,10 @@ module.exports = class MyBrandOAuth2Client extends OAuth2Client {
       path: '/openapi/platform/getDeviceRealTimeData',
       headers: {
         'Content-Type': 'application/json',
-        'x-access-key': this.constructor.CLIENT_SECRET,
+        'x-access-key': this._clientSecret,
       },
       body: JSON.stringify({
-        appkey: this.constructor.CLIENT_ID,
+        appkey: this._clientId,
         lang: '_en_US',
         ps_key_list: psKeyList,
         // sn_list: snList,
@@ -204,16 +220,16 @@ module.exports = class MyBrandOAuth2Client extends OAuth2Client {
       path: '/openapi/platform/getOpenPointInfo',
       headers: {
         'Content-Type': 'application/json',
-        'x-access-key': this.constructor.CLIENT_SECRET,
+        'x-access-key': this._clientSecret,
       },
       body: JSON.stringify({
-        appkey: this.constructor.CLIENT_ID,
+        appkey: this._clientId,
         // lang: '_en_US',
         // ps_ids: `${psId}`, // Comma-separated list of power station IDs
         device_type: deviceType, // 1-55 see https://developer-api.isolarcloud.com/#/document/md?id=12135&project_id=1&version=V2
         sn_list: snList,
         page: 1,
-        size: 9999,
+        size: 1000,
       }),
     });
   }


### PR DESCRIPTION
## Summary

Adds support for selecting an iSolarCloud region during pairing, so the app works with EU, AU, CN, and International gateways rather than being hard-coded to a single endpoint.

- Registers per-region OAuth2 configs (EU, AU, CN, INTL) with their respective gateway hosts
- Adds a `pick_region.html` pairing step to each driver (inverter, battery, meter, charger)
- Fixes `queryPowerStationList` / `getDeviceListByPsId` / `getOpenPointInfo` requests rejecting with `result_code 010 "Parameter:size is over 1000"` by capping `size` at the API maximum of 1000 (was 9999)

## Notes
- Requires apps to be registered in each region, tested only in AU.
- `size` is now a hard cap of 1000; accounts with more than 1000 plants/devices would be truncated. Pagination could be added later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)